### PR TITLE
feat: 전략 설명 페이지에서 구체적 수식·임계값 제거 (노하우 보호)

### DIFF
--- a/frontend/lib/screens/portfolio_screen.dart
+++ b/frontend/lib/screens/portfolio_screen.dart
@@ -604,7 +604,7 @@ class _AtrStopRow extends StatelessWidget {
               Icon(statusIcon, size: 13, color: statusColor),
               const SizedBox(width: 4),
               Text(
-                'ATR 스톱 (균형형×2.0)',
+                'ATR 스톱',
                 style: TextStyle(
                     fontSize: 11,
                     color: statusColor,
@@ -660,10 +660,6 @@ class _AtrStopRow extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 3),
-          Text(
-            '현재가 ${holding.formatPrice(holding.currentPrice)}  →  스톱 ${holding.formatPrice(atrStop)}  │  20일 고점 기준',
-            style: const TextStyle(fontSize: 10, color: Colors.grey),
-          ),
         ],
       ),
     );

--- a/frontend/lib/screens/strategy_guide_screen.dart
+++ b/frontend/lib/screens/strategy_guide_screen.dart
@@ -18,12 +18,10 @@ class StrategyGuideScreen extends StatelessWidget {
           color: Color(0xFFEF5350),
           icon: Icons.trending_up,
           params: [
-            ('ATR 승수', '1.5'),
             ('리밸런싱', '격주'),
-            ('TOP N', '15'),
           ],
           entryConditions: _commonEntryConditions,
-          stopLoss: 'ATR 기반 동적 (20d High − ATR × 1.5)',
+          stopLoss: 'ATR 기반 동적 스톱로스',
           positionSizing: '복합점수 비례 배분, 최대 10%/종목',
           backtestResult: 'CAGR +48.1% | MDD -1.3% | 샤프 3.94 | 승률 79.8%',
         ),
@@ -33,12 +31,10 @@ class StrategyGuideScreen extends StatelessWidget {
           color: Color(0xFF42A5F5),
           icon: Icons.balance,
           params: [
-            ('ATR 승수', '2.0'),
             ('리밸런싱', '격주'),
-            ('TOP N', '10'),
           ],
           entryConditions: _commonEntryConditions,
-          stopLoss: 'ATR 기반 동적 (20d High − ATR × 2.0)',
+          stopLoss: 'ATR 기반 동적 스톱로스',
           positionSizing: '복합점수 비례 배분, 최대 10%/종목',
           backtestResult: 'CAGR +56.8% | MDD -1.5% | 샤프 3.96 | 승률 76.7%',
         ),
@@ -48,12 +44,10 @@ class StrategyGuideScreen extends StatelessWidget {
           color: Color(0xFF66BB6A),
           icon: Icons.security,
           params: [
-            ('ATR 승수', '2.5'),
             ('리밸런싱', '격주'),
-            ('TOP N', '7'),
           ],
           entryConditions: _commonEntryConditions,
-          stopLoss: 'ATR 기반 동적 (20d High − ATR × 2.5)',
+          stopLoss: 'ATR 기반 동적 스톱로스',
           positionSizing: '복합점수 비례 배분, 최대 10%/종목',
           backtestResult: 'CAGR +63.5% | MDD -3.2% | 샤프 3.52 | 승률 71.6%',
         ),
@@ -101,13 +95,13 @@ class StrategyGuideScreen extends StatelessWidget {
 }
 
 const _commonEntryConditions = [
-  'ADX ≥ 20',
-  'RSI 50 ~ 77',
-  '20MA > 50MA > 200MA (정배열)',
-  'HH-HL ≥ 2 (60일 내)',
-  '현재가 ≥ 52주 고점 × 75%',
-  '거래량 스파이크 < 3× (20일 평균)',
-  '5일 급등락 < ±10%',
+  '추세 강도 조건 (ADX)',
+  'RSI 모멘텀 범위 조건',
+  '이동평균 정배열 조건',
+  '상승 추세 구조 확인 (HH-HL)',
+  '52주 고점 대비 근접성 조건',
+  '거래량 급변 배제',
+  '단기 급등락 배제',
   '현재가 > ATR 기반 스톱로스',
 ];
 
@@ -262,9 +256,8 @@ class _StrategyOverviewCard extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(
-                'Stop Loss = 20일 최고가 − ATR(14) × 승수',
+                'ATR(변동성 지표) 기반으로 개별 종목의 최적 스톱로스를 동적 산출',
                 style: theme.textTheme.bodySmall?.copyWith(
-                  fontFamily: 'monospace',
                   color: colorScheme.secondary,
                   fontWeight: FontWeight.w600,
                 ),
@@ -310,12 +303,12 @@ class _StrategyOverviewCard extends StatelessWidget {
 }
 
 const _filterSteps = [
-  ('ADX ≥ 20 (추세 강도)', 'Average Directional Index로 추세가 충분히 강한 종목만 선택'),
-  ('MA 정배열 (추세 방향)', '20MA > 50MA > 200MA — 단·중·장기 추세 모두 상향'),
-  ('RSI 50 ~ 77 (과매수 배제)', '모멘텀이 살아있되 과열 구간(>77) 진입 금지'),
-  ('HH-HL ≥ 2회 (상승 구조)', '60일 내 고점 갱신 + 저점 상승 패턴이 2회 이상 확인'),
-  ('52주 고점 대비 ≥ 75%', '고점 대비 25% 이상 하락한 종목 제외'),
-  ('거래량 급변/급등락 배제', '20일 평균 대비 3× 거래량 스파이크, 5일 ±10% 급등락 제외'),
+  ('추세 강도 필터 (ADX)', 'Average Directional Index로 추세가 충분히 강한 종목만 선택'),
+  ('이동평균 정배열 확인', '단·중·장기 이동평균이 모두 상향 정렬된 종목 선택'),
+  ('RSI 모멘텀 필터', '모멘텀이 살아있되 과열 구간 진입 금지'),
+  ('상승 구조 확인 (HH-HL)', '고점 갱신과 저점 상승 패턴의 반복 확인'),
+  ('52주 고점 대비 근접성 조건', '고점 대비 과도하게 하락한 종목 제외'),
+  ('거래량 급변/급등락 배제', '비정상적인 거래량 및 급격한 가격 변동 종목 제외'),
   ('현재가 > 스톱로스', 'ATR 기반 동적 스톱 아래로 이미 하락한 종목 진입 불가'),
 ];
 
@@ -553,11 +546,11 @@ class _EntryConditionsCard extends StatelessWidget {
 
 // 백테스트 결과 데이터
 const _backtestRows = [
-  ('공격적', '1.5', '15', '+48.1%', '-1.3%', '3.94', '79.8%', Color(0xFFEF5350)),
-  ('균형형', '2.0', '10', '+56.8%', '-1.5%', '3.96', '76.7%', Color(0xFF42A5F5)),
-  ('보수적', '2.5', '7', '+63.5%', '-3.2%', '3.52', '71.6%', Color(0xFF66BB6A)),
-  ('적응형', '2.0', '10', '+49.0%', '-3.2%', '3.76', '78.4%', Color(0xFFAB47BC)),
-  ('SPY', '-', '-', '+12.6%', '-31.0%', '0.82', '64.3%', Color(0xFF9E9E9E)),
+  ('공격적', '+48.1%', '-1.3%', '3.94', '79.8%', Color(0xFFEF5350)),
+  ('균형형', '+56.8%', '-1.5%', '3.96', '76.7%', Color(0xFF42A5F5)),
+  ('보수적', '+63.5%', '-3.2%', '3.52', '71.6%', Color(0xFF66BB6A)),
+  ('적응형', '+49.0%', '-3.2%', '3.76', '78.4%', Color(0xFFAB47BC)),
+  ('SPY', '+12.6%', '-31.0%', '0.82', '64.3%', Color(0xFF9E9E9E)),
 ];
 
 class _BacktestResultTable extends StatelessWidget {
@@ -609,7 +602,7 @@ class _BacktestResultTable extends StatelessWidget {
 
             // 테이블 헤더
             _TableRow(
-              cells: const ['전략', 'ATR', 'Top N', 'CAGR', 'MDD', '샤프', '승률'],
+              cells: const ['전략', 'CAGR', 'MDD', '샤프', '승률'],
               isHeader: true,
               rowColor: colorScheme.surfaceContainerHighest,
               textColor: colorScheme.onSurfaceVariant,
@@ -623,14 +616,14 @@ class _BacktestResultTable extends StatelessWidget {
               return Padding(
                 padding: const EdgeInsets.only(bottom: 2),
                 child: _TableRow(
-                  cells: [row.$1, row.$2, row.$3, row.$4, row.$5, row.$6, row.$7],
+                  cells: [row.$1, row.$2, row.$3, row.$4, row.$5],
                   isHeader: false,
                   rowColor: isSpy
                       ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.3)
-                      : row.$8.withValues(alpha: 0.08),
-                  textColor: isSpy ? colorScheme.onSurfaceVariant : row.$8,
+                      : row.$6.withValues(alpha: 0.08),
+                  textColor: isSpy ? colorScheme.onSurfaceVariant : row.$6,
                   theme: theme,
-                  accentColor: row.$8,
+                  accentColor: row.$6,
                   isBenchmark: isSpy,
                 ),
               );
@@ -688,8 +681,8 @@ class _TableRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 컬럼 너비 비율: [전략, ATR, TopN, CAGR, MDD, 샤프, 승률]
-    const flexes = [2, 1, 1, 2, 2, 1, 2];
+    // 컬럼 너비 비율: [전략, CAGR, MDD, 샤프, 승률]
+    const flexes = [2, 2, 2, 1, 2];
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
@@ -701,8 +694,8 @@ class _TableRow extends StatelessWidget {
         children: cells.asMap().entries.map((e) {
           final idx = e.key;
           final text = e.value;
-          final isCAGR = idx == 3;
-          final isMDD = idx == 4;
+          final isCAGR = idx == 1;
+          final isMDD = idx == 2;
 
           Color cellColor = textColor;
           if (!isHeader && !isBenchmark) {
@@ -864,25 +857,23 @@ class _ScoreFormulaCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Score = ADX × 0.4 + 3M_Return × 0.3\n'
-              '      + Sector_Strength × 0.2 + Vol_Stability × 0.1',
+              '복수의 기술적 지표를 종합한 복합 점수로 종목을 순위화합니다.',
               style: theme.textTheme.bodyMedium?.copyWith(
-                fontFamily: 'monospace',
-                color: colorScheme.secondary,
-                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+                height: 1.5,
               ),
             ),
             const Divider(height: 20),
-            _InfoRow(label: 'ADX', value: '추세 강도 (40% 가중)'),
+            _InfoRow(label: '추세 강도', value: '추세의 방향성과 강도를 측정'),
             const SizedBox(height: 4),
-            _InfoRow(label: '3M Return', value: '3개월 수익률 (30% 가중)'),
+            _InfoRow(label: '수익 모멘텀', value: '최근 가격 모멘텀 측정'),
             const SizedBox(height: 4),
-            _InfoRow(label: 'Sector', value: '섹터 ETF 상대강도 (20% 가중)'),
+            _InfoRow(label: '섹터 강도', value: '섹터 ETF 기반 상대강도'),
             const SizedBox(height: 4),
-            _InfoRow(label: 'Vol Stability', value: '변동성 안정성 (10% 가중)'),
+            _InfoRow(label: '변동성 안정성', value: '변동성 기반 안정성 측정'),
             const SizedBox(height: 12),
             Text(
-              '스코어 상위 TOP N 종목을 점수 비례로 배분하며,\n종목당 최대 비중 10%를 상한으로 cap 처리합니다.',
+              '스코어 상위 종목을 점수 비례로 배분하며,\n종목당 최대 비중을 상한으로 cap 처리합니다.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: colorScheme.onSurfaceVariant,
                 height: 1.5,
@@ -1006,17 +997,17 @@ const _glossaryTerms = [
   (
     'ADX',
     'Average Directional Index',
-    '추세 강도 지표. 20 이상이면 유효한 추세, 25 이상이면 강한 추세',
+    '추세 강도 지표. 추세의 강도를 수치로 나타내며, 높을수록 강한 추세를 의미',
   ),
   (
     'RSI',
     'Relative Strength Index',
-    '상대강도지수. 과매수(>77) / 과매도(<30) 판단에 사용',
+    '상대강도지수. 가격 모멘텀을 측정하는 오실레이터 지표',
   ),
   (
     '정배열',
     'MA Alignment',
-    '20MA > 50MA > 200MA로 단·중·장기 이동평균이 순서대로 정렬된 상태',
+    '단·중·장기 이동평균이 순서대로 정렬된 상태 (상승 추세의 신호)',
   ),
   (
     'HH-HL',


### PR DESCRIPTION
## Summary
- `strategy_guide_screen.dart`: ADX/RSI/ATR 임계값, 스코어 산식(가중치), 백테스트 테이블의 ATR 승수·Top N 컬럼 제거
- `portfolio_screen.dart`: ATR 스톱 위젯에서 `균형형×2.0` 파라미터 표기 및 `20일 고점 기준` 설명 텍스트 제거
- 전략의 개념적 설명은 유지하고 구체적 임계값·수식만 제거

## Test plan
- [x] `fvm flutter test` 43개 테스트 전부 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)